### PR TITLE
Melhora a usabilidade da paginação de resultados

### DIFF
--- a/escavador/resources/__init__.py
+++ b/escavador/resources/__init__.py
@@ -7,3 +7,4 @@ from .helpers.enums_v1 import (TiposMonitoramentosTribunal,
 from .helpers.enums_v2 import (SiglaTribunal,
                                CriterioOrdenacao,
                                Ordem)
+from .helpers.lista_resultados import ListaResultados

--- a/escavador/resources/helpers/consume_cursor.py
+++ b/escavador/resources/helpers/consume_cursor.py
@@ -3,6 +3,7 @@ import re
 from typing import Dict, Callable, List
 
 from escavador.method import Method
+from .lista_resultados import ListaResultados
 
 _methods = Method(api_version=2)
 
@@ -17,7 +18,7 @@ def consumir_cursor(cursor: str) -> Dict:
     return _methods.get(endpoint_cursor)
 
 
-def json_to_class(resposta: Dict, constructor: Callable, add_cursor=False) -> List:
+def json_to_class(resposta: Dict, constructor: Callable, add_cursor=False) -> ListaResultados:
     """Instancia os itens de uma resposta a partir de um construtor
 
     :param resposta: a resposta da primeira requisição, onde 'items' é uma lista de dicts (jsons)
@@ -27,7 +28,7 @@ def json_to_class(resposta: Dict, constructor: Callable, add_cursor=False) -> Li
     """
     items = resposta["resposta"]["items"]
     cursor_url = resposta["resposta"].get("links", {}).get("next", "")
-    return (
+    return ListaResultados(
         [constructor(item, ultimo_cursor=cursor_url) for item in items]
         if add_cursor
         else [constructor(item) for item in items]

--- a/escavador/resources/helpers/lista_resultados.py
+++ b/escavador/resources/helpers/lista_resultados.py
@@ -1,0 +1,34 @@
+class ListaResultados(list):
+
+    def continuar_busca(self) -> "ListaResultados":
+        """Retorna a próxima página de resultados, caso exista."""
+        return self[-1].continuar_busca() if len(self) else ListaResultados()
+
+    def mais_paginas(self, num_paginas: int = 1) -> int:
+        """Extende a lista de resultados com mais resultados, caso existam.
+
+        :param num_paginas: informa quantas páginas adicionais devem ser solicitadas.
+        Se omitido, busca-se apenas a próxima página.
+        :return: Número de páginas adicionais recebidas com sucesso.
+        """
+        return sum(int(self._mais_uma_pagina()) for _ in range(num_paginas))
+
+    def _mais_uma_pagina(self) -> bool:
+        """Continua a busca de resultados, caso existam mais páginas.
+
+        :return: True se recebeu uma nova página com sucesso, False caso contrário.
+        """
+        if not len(self):
+            return False
+
+        novos_resultados = self[-1].continuar_busca()
+
+        if not novos_resultados:
+            return False
+
+        if len(novos_resultados) > 1 and isinstance(novos_resultados[1], ListaResultados):
+            novos_resultados = novos_resultados[1]
+
+        self.extend(novos_resultados)
+
+        return True

--- a/escavador/resources/helpers/lista_resultados.py
+++ b/escavador/resources/helpers/lista_resultados.py
@@ -1,4 +1,10 @@
-class ListaResultados(list):
+class CustomListTypeHint(type):
+    def __getitem__(self, item):
+        if isinstance(item, type):
+            item = item.__name__
+        return f"{self.__name__}[{item}]"
+
+class ListaResultados(list, metaclass=CustomListTypeHint):
 
     def continuar_busca(self) -> "ListaResultados":
         """Retorna a próxima página de resultados, caso exista."""
@@ -14,7 +20,7 @@ class ListaResultados(list):
         return sum(int(self._mais_uma_pagina()) for _ in range(num_paginas))
 
     def _mais_uma_pagina(self) -> bool:
-        """Continua a busca de resultados, caso existam mais páginas.
+        """Extende a lista de resultados com a próxima página, caso exista.
 
         :return: True se recebeu uma nova página com sucesso, False caso contrário.
         """

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 
 from typing import Optional, List, Dict, Tuple, Union, TYPE_CHECKING, Type
 
-from escavador import ListaResultados
+from escavador.resources import ListaResultados
 from escavador.exceptions import FailedRequest
 from escavador.resources.helpers.enums_v2 import CriterioOrdenacao, Ordem, SiglaTribunal
 from escavador.resources.helpers.endpoint import DataEndpoint

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -59,7 +59,7 @@ class EnvolvidoEncontrado:
 
         return cls(
             nome=json_dict["nome"],
-            tipo_pessoa=json_dict["tipo_pessoa"],
+            tipo_pessoa=json_dict.get("tipo_pessoa", "FISICA"), # Se não houver tipo_pessoa, assume-se que é advogado.
             quantidade_processos=json_dict["quantidade_processos"],
             last_valid_cursor=last_cursor,
             _classe_buscada=classe_buscada,

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 from typing import Optional, List, Dict, Tuple, Union, TYPE_CHECKING, Type
 
+from escavador import ListaResultados
 from escavador.exceptions import FailedRequest
 from escavador.resources.helpers.enums_v2 import CriterioOrdenacao, Ordem, SiglaTribunal
 from escavador.resources.helpers.endpoint import DataEndpoint
@@ -65,7 +66,7 @@ class EnvolvidoEncontrado:
             _classe_buscada=classe_buscada,
         )
 
-    def continuar_busca(self) -> Union[List["DataEndpoint"], FailedRequest]:
+    def continuar_busca(self) -> Union[ListaResultados["DataEndpoint"], FailedRequest]:
         """Retorna mais resultados para a busca que gerou o objeto atual.
 
         :return: lista contendo a próxima página de resultados, ou FailedRequest em caso de erro

--- a/escavador/v2/resources/movimentacao.py
+++ b/escavador/v2/resources/movimentacao.py
@@ -107,7 +107,7 @@ class Movimentacao(DataEndpoint):
             else Processo.movimentacoes(processo, **kwargs)
         )
 
-    def continuar_busca(self) -> Union[List["Movimentacao"], FailedRequest]:
+    def continuar_busca(self) -> Union[ListaResultados["Movimentacao"], FailedRequest]:
         """Retorna mais resultados para a busca que gerou a movimentação atual.
 
         :return: lista de movimentações ou FailedRequest
@@ -123,4 +123,4 @@ class Movimentacao(DataEndpoint):
 
             return json_to_class(resposta, self.from_json, add_cursor=True)
 
-        return []
+        return ListaResultados()

--- a/escavador/v2/resources/movimentacao.py
+++ b/escavador/v2/resources/movimentacao.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional, Dict, Union, List, TYPE_CHECKING
 
+from escavador.resources import ListaResultados
 from escavador.exceptions import FailedRequest
 from escavador.v2.resources.tribunal import Tribunal
 from escavador.resources.helpers.consume_cursor import consumir_cursor, json_to_class
@@ -88,7 +89,7 @@ class Movimentacao(DataEndpoint):
     @staticmethod
     def movimentacoes(
         processo: Union["Processo", str], **kwargs
-    ) -> Union[List["Movimentacao"], FailedRequest]:
+    ) -> Union[ListaResultados["Movimentacao"], FailedRequest]:
         """Busca as movimentações de um processo.
 
         Alias do método `Processo.movimentacoes`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.2.2"
+version = "0.3.0"
 description = "A library to  interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",


### PR DESCRIPTION
Cria o tipo `ListaResultados` que herda do tipo `list`, com os métodos:

```
continuar_busca() -> Retorna a próxima página de resultados como `ListaResultados`.

mais_paginas(num_paginas = 1) -> Extende a `ListaResultados` atual com até `num_paginas` (default: 1) páginas adicionais. Retorna o número de páginas recebidas com sucesso.
```

Também traz a metaclass `CustomListTypeHint` que permite usar `ListaResultados` em type hints com especificação do tipo do conteúdo. Ex: `ListaResultados[Processo]` ao invés de somente `ListaResultados`.

O tipo `ListaResultados` fica disponível no namespace raíz da biblioteca escavador (`escavador.ListaResultados`).

Modifica os métodos que retornam listas de processos ou movimentações para que retornem `ListaResultados`. Atualiza docstrings para refletir essa mudança.

Adequa o método `Processo.por_oab()` para que retorne os dados do advogado além da lista do processo, como recentemente alterado no endpoint `v2/advogado/processos`.

Além disso, faz pequenas correções em docstrings e type hints da V2.