### PR TITLE
Usando query params em GETs

### DIFF
--- a/escavador/v1/resources/busca.py
+++ b/escavador/v1/resources/busca.py
@@ -26,10 +26,10 @@ class Busca(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'q': termo,
             'qo': tipo_termo.value,
             'limit': limit,
             'page': page
         }
-        return cls.methods.get("busca", data=data)
+        return cls.methods.get("busca", params=params)

--- a/escavador/v1/resources/callback.py
+++ b/escavador/v1/resources/callback.py
@@ -26,7 +26,7 @@ class Callback(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             "data_maxima": data_maxima.strftime("%Y-%m-%d %H:%M:%S") if data_maxima else None,
             "data_minima": data_minima.strftime("%Y-%m-%d %H:%M:%S") if data_minima else None,
             "evento": evento,
@@ -35,7 +35,7 @@ class Callback(EndpointV1):
             "status": status.value
         }
 
-        return cls.methods.get('callbacks', data=data)
+        return cls.methods.get('callbacks', params=params)
 
     @classmethod
     def marcarRecebido(cls, ids: List) -> Dict:

--- a/escavador/v1/resources/diario_oficial.py
+++ b/escavador/v1/resources/diario_oficial.py
@@ -24,11 +24,11 @@ class DiarioOficial(EndpointV1):
         :param page: número da página do diário oficial
         :return: Dict
         """
-        data = {
+        params = {
             "page": page
         }
 
-        return cls.methods.get(f"diarios/{id_diario}", data=data)
+        return cls.methods.get(f"diarios/{id_diario}", params=params)
 
     @classmethod
     def download_pdf_pagina(cls, id_diario: int, page: int, path: str, nome_arquivo: str) -> Dict:

--- a/escavador/v1/resources/instituicao.py
+++ b/escavador/v1/resources/instituicao.py
@@ -28,11 +28,11 @@ class Instituicao(EndpointV1):
         :return Dict
         """
 
-        data = {
+        params = {
             'limit': limit,
             'page': page
         }
-        return cls.methods.get(f"instituicoes/{id_instituicao}/processos", data=data)
+        return cls.methods.get(f"instituicoes/{id_instituicao}/processos", params=params)
 
     @classmethod
     def get_pessoas_instituicao(cls, id_instituicao: int, *, limit: Optional[int] = None,
@@ -45,8 +45,8 @@ class Instituicao(EndpointV1):
         :return Dict
         """
 
-        data = {
+        params = {
             'limit': limit,
             'page': page
         }
-        return cls.methods.get(f"instituicoes/{id_instituicao}/pessoas", data=data)
+        return cls.methods.get(f"instituicoes/{id_instituicao}/pessoas", params=params)

--- a/escavador/v1/resources/jurisprudencia.py
+++ b/escavador/v1/resources/jurisprudencia.py
@@ -35,7 +35,7 @@ class Jurisprudencia(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'q': termo,
             'ordena_por': ordena_por,
             'de_data': de_data.strftime("%Y%m%d") if de_data else None,
@@ -45,9 +45,9 @@ class Jurisprudencia(EndpointV1):
 
         if filtros:
             for filtro in filtros:
-                data.update(filtro)
+                params.update(filtro)
 
-        return cls.methods.get('jurisprudencias/busca', data=data)
+        return cls.methods.get('jurisprudencias/busca', params=params)
 
     @classmethod
     def get_documento_jurisprudencia(cls, tipo_documento: str, id_documento: int) -> Dict:

--- a/escavador/v1/resources/legislacao.py
+++ b/escavador/v1/resources/legislacao.py
@@ -31,7 +31,7 @@ class Legislacao(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'q': termo,
             'ordena_por': ordena_por,
             'de_data': de_data.strftime("%Y%m%d") if de_data else None,
@@ -40,7 +40,7 @@ class Legislacao(EndpointV1):
             'filtro': filtro
         }
 
-        return cls.methods.get('legislacoes/busca', data=data)
+        return cls.methods.get('legislacoes/busca', params=params)
 
     @classmethod
     def get_documento_legislacao(cls, tipo_documento: str, id_documento: int) -> Dict:

--- a/escavador/v1/resources/pessoa.py
+++ b/escavador/v1/resources/pessoa.py
@@ -26,9 +26,9 @@ class Pessoa(EndpointV1):
         :param limit: limita a quantidade de registros retornados
         :return: Dict
         """
-        data = {
+        params = {
             'limit': limit,
             'page': page
         }
 
-        return cls.methods.get(f"pessoas/{id_pessoa}/processos", data=data)
+        return cls.methods.get(f"pessoas/{id_pessoa}/processos", params=params)

--- a/escavador/v1/resources/processo.py
+++ b/escavador/v1/resources/processo.py
@@ -164,11 +164,11 @@ class Processo(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'page': page
         }
 
-        return cls.methods.get(f"oab/{estado_oab}/{numero_oab}/processos", data=data)
+        return cls.methods.get(f"oab/{estado_oab}/{numero_oab}/processos", params=params)
 
     @classmethod
     def por_id_em_diarios(cls, id_processo: int) -> Dict:
@@ -191,12 +191,12 @@ class Processo(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'limit': limit,
             'page': page
         }
 
-        return cls.methods.get(f"processos/{id_processo}/movimentacoes", data=data)
+        return cls.methods.get(f"processos/{id_processo}/movimentacoes", params=params)
 
     @classmethod
     def processo_por_numero_em_diarios(cls, numero_unico: str, *, match_exato: Optional[bool] = None) -> Dict:
@@ -207,11 +207,11 @@ class Processo(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'match_exato': match_exato
         }
 
-        return cls.methods.get(f"processos/numero/{numero_unico}", data=data)
+        return cls.methods.get(f"processos/numero/{numero_unico}", params=params)
 
     @classmethod
     def get_envolvidos_processo(cls, id_processo: int, *, limit: Optional[int] = None,
@@ -224,12 +224,12 @@ class Processo(EndpointV1):
         :return: Dict
         """
 
-        data = {
+        params = {
             'limit': limit,
             'page': page
         }
 
-        return cls.methods.get(f"processos/{id_processo}/envolvidos", data=data)
+        return cls.methods.get(f"processos/{id_processo}/envolvidos", params=params)
 
     @classmethod
     def get_pdf(cls, link_pdf: str, path: str, nome_arquivo: str) -> Dict:

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -112,10 +112,10 @@ class Processo(DataEndpoint):
 
         >>> Processo.movimentacoes("0000000-00.0000.0.00.0000") # doctest: +SKIP
         """
-        data = kwargs
+        params = kwargs
 
         first_response = Processo.methods.get(
-            f"processos/numero_cnj/{numero_cnj}/movimentacoes", data=data, **kwargs
+            f"processos/numero_cnj/{numero_cnj}/movimentacoes", params=params, **kwargs
         )
 
         if not first_response["sucesso"]:
@@ -266,19 +266,18 @@ class Processo(DataEndpoint):
         ...                             ordem=Ordem.ASC,
         ...                             tribunais=[SiglaTribunal.TJBA]) # doctest: +SKIP
         """
-        data = {
+
+
+        params = {
             "nome": nome,
             "cpf_cnpj": cpf_cnpj,
             "tribunais": tribunais,
-        }
-
-        params = {
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
         }
 
         first_response = Processo.methods.get(
-            "envolvido/processos", data=data, params=params, **kwargs
+            "envolvido/processos", params=params, **kwargs
         )
 
         if not first_response["sucesso"]:
@@ -321,17 +320,15 @@ class Processo(DataEndpoint):
         ...                  ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                  ordem=Ordem.DESC) # doctest: +SKIP
         """
-        data = {
+        params = {
             "oab_numero": f"{numero}",
             "oab_estado": estado,
-        }
-        params = {
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
         }
 
         first_response = Processo.methods.get(
-            "advogado/processos", data=data, params=params, **kwargs
+            "advogado/processos", params=params, **kwargs
         )
 
         if not first_response["sucesso"]:


### PR DESCRIPTION
Modifica métodos que fazem GET requests para que, a menos que não seja possível, utilizem query params ao invés do body para passar seus parâmetros.