### PR TITLE
Tribunais

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ tribunais_disponiveis = Tribunal.sistemas_disponiveis()
 
 #### V2:
 
-| Módulo                | Link API                                                             |
-|-----------------------|----------------------------------------------------------------------|
-| v2.Processo           | https://api.escavador.com/v2/docs/#processos                         |
+| Módulo      | Link API                                     |
+|-------------|----------------------------------------------|
+| v2.Processo | https://api.escavador.com/v2/docs/#processos |
+| v2.Tribunal | https://api.escavador.com/v2/docs/#tribunais |

--- a/escavador/resources/helpers/consume_cursor.py
+++ b/escavador/resources/helpers/consume_cursor.py
@@ -28,10 +28,18 @@ def json_to_class(
     :param add_cursor: se True, adiciona o cursor da resposta ao objeto instanciado
     :return: uma lista de objetos instanciados
     """
-    items = resposta["resposta"]["items"]
-    cursor_url = resposta["resposta"].get("links", {}).get("next", "")
+    if isinstance(resposta, dict):
+        resposta = resposta["resposta"]
+        items, cursor_url = resposta["items"], resposta.get("links", {}).get("next", "")
+    else:
+        items, cursor_url = resposta, ""
+
     return ListaResultados(
-        [constructor(item, ultimo_cursor=cursor_url) for item in items]
-        if add_cursor
-        else [constructor(item) for item in items]
+        result
+        for result in (
+            [constructor(item, ultimo_cursor=cursor_url) for item in items]
+            if add_cursor and cursor_url
+            else [constructor(item) for item in items]
+        )
+        if result is not None
     )

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -167,6 +167,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        incluir_homonimos: Optional[bool] = None,
         **kwargs,
     ) -> Union[
         Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
@@ -180,6 +181,9 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
+        especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
+        diferente. Só é permitido se cpf_cnpj for informado.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -188,13 +192,15 @@ class Processo(DataEndpoint):
         >>> Processo.por_cpf("12345678999",
         ...                  ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                  ordem=Ordem.ASC,
-        ...                  tribunais=[SiglaTribunal.STF]) # doctest: +SKIP
+        ...                  tribunais=[SiglaTribunal.STF],
+        ...                  incluir_homonimos=True) # doctest: +SKIP
         """
         return Processo.por_envolvido(
             cpf_cnpj=cpf,
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            incluir_homonimos=incluir_homonimos,
             **kwargs,
         )
 
@@ -242,6 +248,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        incluir_homonimos: Optional[bool] = None,
         **kwargs,
     ) -> Union[
         Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
@@ -256,6 +263,9 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
+        especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
+        diferente. Só é permitido se cpf_cnpj for informado.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -267,13 +277,15 @@ class Processo(DataEndpoint):
         ...                             tribunais=[SiglaTribunal.TJBA]) # doctest: +SKIP
         """
 
-
         params = {
             "nome": nome,
             "cpf_cnpj": cpf_cnpj,
             "tribunais": tribunais,
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
+            "incluir_homonimos": int(incluir_homonimos)
+            if incluir_homonimos is not None
+            else None,
         }
 
         first_response = Processo.methods.get(

--- a/escavador/v2/resources/tribunal.py
+++ b/escavador/v2/resources/tribunal.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Union
 
 from escavador.exceptions import FailedRequest
 from resources.helpers.consume_cursor import json_to_class
@@ -43,8 +43,26 @@ class Tribunal(DataEndpoint):
         )
 
     @staticmethod
-    def listar():
-        response = Tribunal.methods.get("tribunais")
+    def listar(estados: List[str] = None) -> Union[List["Tribunal"], FailedRequest]:
+        """
+        Lista os tribunais em que o Escavador possui crawlers e os estados que cada um abrange.
+
+        No caso de tribunais de instância superior que abrangem todo o território nacional,
+        a lista de estados será vazia.
+
+        :param estados: permite que apenas tribunais que atendem os estados cujas siglas foram
+        especificadas sejam retornados. Se não for especificado, todos os tribunais serão retornados.
+        :return: lista de tribunais
+
+        >>> Tribunal.listar() # doctest: +SKIP
+
+        >>> Tribunal.listar(["SP", "RJ"]) # doctest: +SKIP
+        """
+        dados = {}
+        if estados is not None:
+            dados["estados"] = estados
+
+        response = Tribunal.methods.get("tribunais", data=dados)
         if not response["sucesso"]:
             conteudo = response.get("resposta", {})
             return FailedRequest(status=response["http_status"], **conteudo)

--- a/escavador/v2/resources/tribunal.py
+++ b/escavador/v2/resources/tribunal.py
@@ -21,12 +21,12 @@ class Tribunal(DataEndpoint):
     nome: str
     sigla: str
     categoria: Optional[str] = None
-    estados: List[str] = field(
-        default_factory=list, hash=False, compare=False
-    )  # Será adicionado à API depois
+    estados: List[str] = field(default_factory=list, hash=False, compare=False)
 
     @classmethod
-    def from_json(cls, json_dict: Optional[Dict]) -> Optional["Tribunal"]:
+    def from_json(
+        cls, json_dict: Optional[Dict], *, ultimo_cursor: Optional[str] = None
+    ) -> Optional["Tribunal"]:
         if json_dict is None:
             return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.3.1"
+version = "0.4.0"
 description = "A library to  interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.3.0"
+version = "0.3.1"
 description = "A library to  interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",


### PR DESCRIPTION
Implementa o método `Tribunal.listar()` para consultar a rota `v2/tribunais`.

Adapta a função `json_to_class` em `consume_cursor.py` para também poder receber listas de dicionários ao invés de ter que receber uma resposta inteira de um endpoint.

Adiciona o parâmetro `incluir_homonimos` na busca de processos por envolvido da rota `v2/tribunais`.

Adiciona o atributo `cpfs_com_esse_nome` no retorno da busca de processos por envolvido.