### PR TITLE
Conserta bug com filtro 'tribunais'

### DIFF
--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -280,7 +280,6 @@ class Processo(DataEndpoint):
         params = {
             "nome": nome,
             "cpf_cnpj": cpf_cnpj,
-            "tribunais": tribunais,
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
             "incluir_homonimos": int(incluir_homonimos)
@@ -288,8 +287,12 @@ class Processo(DataEndpoint):
             else None,
         }
 
+        body = {
+            "tribunais": tribunais,
+        }
+
         first_response = Processo.methods.get(
-            "envolvido/processos", params=params, **kwargs
+            "envolvido/processos", params=params, data=body, **kwargs
         )
 
         if not first_response["sucesso"]:

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -282,17 +282,14 @@ class Processo(DataEndpoint):
             "cpf_cnpj": cpf_cnpj,
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
+            "tribunais[]": tribunais,
             "incluir_homonimos": int(incluir_homonimos)
             if incluir_homonimos is not None
             else None,
         }
 
-        body = {
-            "tribunais": tribunais,
-        }
-
         first_response = Processo.methods.get(
-            "envolvido/processos", params=params, data=body, **kwargs
+            "envolvido/processos", params=params, **kwargs
         )
 
         if not first_response["sucesso"]:

--- a/escavador/v2/resources/tribunal.py
+++ b/escavador/v2/resources/tribunal.py
@@ -58,11 +58,11 @@ class Tribunal(DataEndpoint):
 
         >>> Tribunal.listar(["SP", "RJ"]) # doctest: +SKIP
         """
-        dados = {}
+        params = {}
         if estados is not None:
-            dados["estados"] = estados
+            params["estados[]"] = estados
 
-        response = Tribunal.methods.get("tribunais", data=dados)
+        response = Tribunal.methods.get("tribunais", params=params)
         if not response["sucesso"]:
             conteudo = response.get("resposta", {})
             return FailedRequest(status=response["http_status"], **conteudo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.4.1"
+version = "0.4.2"
 description = "A library to  interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",


### PR DESCRIPTION
Identifiquei um bug no método que acessa a rota v2/envolvido/processos da API do Escavador.

Ao utilizar o filtro 'tribunais', o SDK está tentando passar o argumento (um array) como parâmetro de query e não no corpo do request, como deveria. Isso causa um erro 422: UNPROCESSABLE_ENTITY.

Esse PR corrige este erro.