### PR TITLE
Eleva FailedRequest em caso de erro

### DIFF
--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -52,8 +52,10 @@ class EnvolvidoEncontrado:
     tipo_pessoa: str
     quantidade_processos: int = field(hash=False, compare=False)
     cpfs_com_esse_nome: int = field(default=0, hash=False, compare=False)
-    last_valid_cursor: Optional[str] = field(default="", hash=False, compare=False)
-    _classe_buscada: Type["DataEndpoint"] = field(default=None, hash=False, compare=False)
+    last_valid_cursor: Optional[str] = field(default="", hash=False, compare=False, repr=False)
+    _classe_buscada: Type["DataEndpoint"] = field(
+        default=None, hash=False, compare=False, repr=False
+    )
 
     @classmethod
     def from_json(
@@ -153,7 +155,7 @@ class Envolvido(DataEndpoint):
     cnpj: Optional[str] = None
     oabs: List[Oab] = field(default_factory=list)
     advogados: List["Envolvido"] = field(default_factory=list, hash=False, compare=False)
-    last_valid_cursor: str = field(default="", hash=False, compare=False)
+    last_valid_cursor: str = field(default="", hash=False, compare=False, repr=False)
 
     @classmethod
     def from_json(cls, json_dict: Optional[Dict], ultimo_cursor: str = "") -> Optional["Envolvido"]:

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -91,7 +91,7 @@ class EnvolvidoEncontrado:
 
             if not resposta["sucesso"]:
                 conteudo = resposta.get("resposta", {})
-                return FailedRequest(status=resposta["http_status"], **conteudo)
+                raise FailedRequest(status=resposta["http_status"], **conteudo)
 
             self.last_valid_cursor = resposta["resposta"].get("links", {}).get("next", "")
             return json_to_class(resposta, self._classe_buscada.from_json, add_cursor=True)

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -52,10 +52,8 @@ class EnvolvidoEncontrado:
     tipo_pessoa: str
     quantidade_processos: int = field(hash=False, compare=False)
     cpfs_com_esse_nome: int = field(default=0, hash=False, compare=False)
-    last_valid_cursor: str = field(default="None", hash=False, compare=False)
-    _classe_buscada: Type["DataEndpoint"] = field(
-        default=None, hash=False, compare=False
-    )
+    last_valid_cursor: Optional[str] = field(default="", hash=False, compare=False)
+    _classe_buscada: Type["DataEndpoint"] = field(default=None, hash=False, compare=False)
 
     @classmethod
     def from_json(
@@ -93,14 +91,33 @@ class EnvolvidoEncontrado:
                 conteudo = resposta.get("resposta", {})
                 return FailedRequest(status=resposta["http_status"], **conteudo)
 
-            self.last_valid_cursor = (
-                resposta["resposta"].get("links", {}).get("next", "")
-            )
-            return json_to_class(
-                resposta, self._classe_buscada.from_json, add_cursor=True
-            )
+            self.last_valid_cursor = resposta["resposta"].get("links", {}).get("next", "")
+            return json_to_class(resposta, self._classe_buscada.from_json, add_cursor=True)
 
         return ListaResultados()
+
+    def __eq__(self, other):
+        if isinstance(other, Envolvido):
+            # se só tem um CPF com esse nome, podemos dar como certo que é a mesma pessoa
+            # se houver mais que um, não podemos ter certeza
+            return (
+                self.nome == other.nome
+                and self.tipo_pessoa == other.tipo_pessoa
+                and self.cpfs_com_esse_nome < 2
+            )
+        elif isinstance(other, EnvolvidoEncontrado):
+            return (
+                self.nome == other.nome
+                and self.tipo_pessoa == other.tipo_pessoa
+                # se um nome de envolvido foi obtido em uma data anterior (e, por exemplo, salvo como Pickle e depois
+                # recuperado) e o outro foi obtido em uma busca nova, o valor de cpfs_com_esse_nome pode ser diferente.
+                # Por isso, é necessário verificar que ambos sinalizam um cpf único com esse nome.
+                and self.cpfs_com_esse_nome < 2
+                and other.cpfs_com_esse_nome < 2
+            ) or self is other
+        elif isinstance(other, str):
+            return self.nome == other
+        return False
 
 
 @dataclass
@@ -111,7 +128,6 @@ class Envolvido(DataEndpoint):
     :attr quantidade_processos: quantidade de processos onde o envolvido apareceu
     :attr tipo_pessoa: tipo de pessoa do envolvido (ex: "FISICA")
     :attr nome: nome do envolvido (ex: "João da Silva")
-    :attr nome_normalizado: nome do envolvido depois da normalização (como foi buscado no banco de dados)
     :attr prefixo: prefixos do nome do envolvido (ex: "Dr.")
     :attr sufixo: sufixos do nome do envolvido (ex: "Jr.")
     :attr tipo: tipo do envolvido (ex: "Advogado")
@@ -136,15 +152,11 @@ class Envolvido(DataEndpoint):
     cpf: Optional[str] = None
     cnpj: Optional[str] = None
     oabs: List[Oab] = field(default_factory=list)
-    advogados: List["Envolvido"] = field(
-        default_factory=list, hash=False, compare=False
-    )
+    advogados: List["Envolvido"] = field(default_factory=list, hash=False, compare=False)
     last_valid_cursor: str = field(default="", hash=False, compare=False)
 
     @classmethod
-    def from_json(
-        cls, json_dict: Optional[Dict], ultimo_cursor: str = ""
-    ) -> Optional["Envolvido"]:
+    def from_json(cls, json_dict: Optional[Dict], ultimo_cursor: str = "") -> Optional["Envolvido"]:
         if json_dict is None:
             return None
 
@@ -160,9 +172,7 @@ class Envolvido(DataEndpoint):
             cpf=json_dict.get("cpf"),
             cnpj=json_dict.get("cnpj"),
             oabs=[Oab.from_json(o) for o in json_dict.get("oabs", []) if o],
-            advogados=[
-                Envolvido.from_json(a) for a in json_dict.get("advogados", []) if a
-            ],
+            advogados=[Envolvido.from_json(a) for a in json_dict.get("advogados", []) if a],
         )
 
     @property
@@ -177,7 +187,7 @@ class Envolvido(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
-        **kwargs
+        **kwargs,
     ) -> Union[Tuple[Optional[EnvolvidoEncontrado], List["Processo"]], FailedRequest]:
         """Busca os processos envolvendo uma pessoa ou instituição a partir de seu nome e/ou CPF/CNPJ.
 
@@ -197,5 +207,23 @@ class Envolvido(DataEndpoint):
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
-            **kwargs
+            **kwargs,
         )
+
+    def __eq__(self, other):
+        if isinstance(other, EnvolvidoEncontrado):
+            return other == self
+
+        if isinstance(other, Envolvido):
+            return (
+                self.nome == other.nome
+                and self.tipo_pessoa == other.tipo_pessoa
+                and self.cpf == other.cpf
+                and self.cnpj == other.cnpj
+                and self.oabs == other.oabs
+            )
+
+        if isinstance(other, str):
+            return self.nome == other
+
+        return False

--- a/escavador/v2/resources/movimentacao.py
+++ b/escavador/v2/resources/movimentacao.py
@@ -119,7 +119,7 @@ class Movimentacao(DataEndpoint):
 
             if not resposta["sucesso"]:
                 conteudo = resposta.get("resposta", {})
-                return FailedRequest(status=resposta["http_status"], **conteudo)
+                raise FailedRequest(status=resposta["http_status"], **conteudo)
 
             return json_to_class(resposta, self.from_json, add_cursor=True)
 

--- a/escavador/v2/resources/movimentacao.py
+++ b/escavador/v2/resources/movimentacao.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Dict, Union, List, TYPE_CHECKING
+from typing import Optional, Dict, Union, TYPE_CHECKING
 
 from escavador.resources import ListaResultados
 from escavador.exceptions import FailedRequest

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -578,12 +578,12 @@ class ValorCausa:
 class InformacaoComplementar:
     """Informações complementares de um processo.
 
-    :attr valor: texto da informação
     :attr tipo: tipo ou significado da informação
+    :attr valor: texto da informação
     """
 
-    valor: str
     tipo: str
+    valor: str
 
     @classmethod
     def from_json(cls, json_dict: Optional[Dict]) -> Optional["InformacaoComplementar"]:

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -36,10 +36,10 @@ class Processo(DataEndpoint):
 
     numero_cnj: str
     quantidade_movimentacoes: int
-    fontes_tribunais_estao_arquivadas: bool
+    fontes_tribunais_estao_arquivadas: bool = field(hash=False, compare=False)
     ano_inicio: int
-    data_ultima_verificacao: str
-    tempo_desde_ultima_verificacao: str
+    data_ultima_verificacao: str = field(hash=False, compare=False)
+    tempo_desde_ultima_verificacao: str = field(hash=False, compare=False)
     data_ultima_movimentacao: str
     titulo_polo_ativo: Optional[str] = None
     titulo_polo_passivo: Optional[str] = None
@@ -48,33 +48,25 @@ class Processo(DataEndpoint):
     last_valid_cursor: str = field(default="", repr=False, hash=False)
 
     @classmethod
-    def from_json(
-        cls, json_dict: Optional[Dict], ultimo_cursor: str = ""
-    ) -> Optional["Processo"]:
+    def from_json(cls, json_dict: Optional[Dict], ultimo_cursor: str = "") -> Optional["Processo"]:
         if json_dict is None:
             return None
 
         instance = cls(
             numero_cnj=json_dict.get("numero_cnj"),
             quantidade_movimentacoes=json_dict.get("quantidade_movimentacoes", 0),
-            fontes_tribunais_estao_arquivadas=json_dict.get(
-                "fontes_tribunais_estao_arquivadas"
-            ),
+            fontes_tribunais_estao_arquivadas=json_dict.get("fontes_tribunais_estao_arquivadas"),
             titulo_polo_ativo=json_dict.get("titulo_polo_ativo"),
             titulo_polo_passivo=json_dict.get("titulo_polo_passivo"),
             ano_inicio=json_dict.get("ano_inicio"),
             data_inicio=json_dict.get("data_inicio", None),
             data_ultima_movimentacao=json_dict.get("data_ultima_movimentacao", None),
             data_ultima_verificacao=json_dict.get("data_ultima_verificacao", None),
-            tempo_desde_ultima_verificacao=json_dict.get(
-                "tempo_desde_ultima_verificacao", None
-            ),
+            tempo_desde_ultima_verificacao=json_dict.get("tempo_desde_ultima_verificacao", None),
             last_valid_cursor=ultimo_cursor,
         )
         instance.fontes += [
-            FonteProcesso.from_json(fonte)
-            for fonte in json_dict.get("fontes", [])
-            if fonte
+            FonteProcesso.from_json(fonte) for fonte in json_dict.get("fontes", []) if fonte
         ]
 
         return instance
@@ -96,9 +88,7 @@ class Processo(DataEndpoint):
             conteudo = resposta.get("resposta", {})
             return FailedRequest(status=resposta["http_status"], **conteudo)
 
-        return Processo.from_json(
-            resposta["resposta"], resposta.get("links", {}).get("next", "")
-        )
+        return Processo.from_json(resposta["resposta"], resposta.get("links", {}).get("next", ""))
 
     @staticmethod
     def movimentacoes(
@@ -122,9 +112,7 @@ class Processo(DataEndpoint):
             conteudo = first_response.get("resposta", {})
             return FailedRequest(status=first_response["http_status"], **conteudo)
 
-        return json_to_class(
-            first_response, constructor=Movimentacao.from_json, add_cursor=True
-        )
+        return json_to_class(first_response, constructor=Movimentacao.from_json, add_cursor=True)
 
     @staticmethod
     def por_nome(
@@ -133,9 +121,7 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         **kwargs,
-    ) -> Union[
-        Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
-    ]:
+    ) -> Union[Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest]:
         """
         Busca os processos envolvendo uma pessoa ou empresa a partir do seu nome.
 
@@ -169,9 +155,7 @@ class Processo(DataEndpoint):
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
         **kwargs,
-    ) -> Union[
-        Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
-    ]:
+    ) -> Union[Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest]:
         """
         Busca os processos envolvendo uma pessoa a partir de seu CPF.
 
@@ -211,9 +195,7 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         **kwargs,
-    ) -> Union[
-        Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
-    ]:
+    ) -> Union[Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest]:
         """
         Busca os processos envolvendo uma instituição a partir de seu CNPJ.
 
@@ -250,9 +232,7 @@ class Processo(DataEndpoint):
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
         **kwargs,
-    ) -> Union[
-        Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
-    ]:
+    ) -> Union[Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest]:
         """
         Busca os processos envolvendo uma pessoa ou instituição a partir de seu nome e/ou CPF/CNPJ.
 
@@ -283,14 +263,10 @@ class Processo(DataEndpoint):
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
             "tribunais[]": tribunais,
-            "incluir_homonimos": int(incluir_homonimos)
-            if incluir_homonimos is not None
-            else None,
+            "incluir_homonimos": int(incluir_homonimos) if incluir_homonimos is not None else None,
         }
 
-        first_response = Processo.methods.get(
-            "envolvido/processos", params=params, **kwargs
-        )
+        first_response = Processo.methods.get("envolvido/processos", params=params, **kwargs)
 
         if not first_response["sucesso"]:
             conteudo = first_response.get("resposta", {})
@@ -313,9 +289,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         **kwargs,
-    ) -> Union[
-        Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest
-    ]:
+    ) -> Union[Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]], FailedRequest]:
         """
         Busca os processos de um advogado a partir de sua carteira da OAB.
 
@@ -339,9 +313,7 @@ class Processo(DataEndpoint):
             "ordem": ordem.value if ordem else None,
         }
 
-        first_response = Processo.methods.get(
-            "advogado/processos", params=params, **kwargs
-        )
+        first_response = Processo.methods.get("advogado/processos", params=params, **kwargs)
 
         if not first_response["sucesso"]:
             conteudo = first_response.get("resposta", {})
@@ -417,11 +389,9 @@ class FonteProcesso:
     arquivado: Optional[bool] = None
     url: Optional[str] = None
     caderno: Optional[str] = None
-    data_ultima_verificacao: Optional[str] = None
+    data_ultima_verificacao: Optional[str] = field(default=None, hash=False, compare=False)
     tribunal: Optional[Tribunal] = None
-    capa: Optional["CapaProcessoTribunal"] = field(
-        default=None, hash=False, compare=False
-    )
+    capa: Optional["CapaProcessoTribunal"] = field(default=None, hash=False, compare=False)
     envolvidos: List[Envolvido] = field(default_factory=list, hash=False, compare=False)
 
     @classmethod
@@ -476,9 +446,7 @@ class CapaProcessoTribunal:
     """
 
     assunto_principal_normalizado: Optional["Assunto"] = None
-    assuntos_normalizados: List["Assunto"] = field(
-        default_factory=list, hash=False, compare=False
-    )
+    assuntos_normalizados: List["Assunto"] = field(default_factory=list, hash=False, compare=False)
     classe: Optional[str] = None
     assunto: Optional[str] = None
     area: Optional[str] = None
@@ -562,7 +530,7 @@ class ValorCausa:
 
     valor: float
     moeda: str
-    valor_formatado: str
+    valor_formatado: str = field(hash=False, compare=False)
 
     @classmethod
     def from_json(cls, json_dict: Optional[Dict]) -> Optional["ValorCausa"]:
@@ -584,10 +552,7 @@ class ValorCausa:
             f"{moeda} "
             + "".join(
                 reversed(
-                    [
-                        f"{x}{'' if i % 3 and i else '.'}"
-                        for i, x in enumerate(reversed(inteiros))
-                    ]
+                    [f"{x}{'' if i % 3 and i else '.'}" for i, x in enumerate(reversed(inteiros))]
                 )
             ).strip(".")
             + f",{centavos}"

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -86,7 +86,7 @@ class Processo(DataEndpoint):
 
         if not resposta["sucesso"]:
             conteudo = resposta.get("resposta", {})
-            return FailedRequest(status=resposta["http_status"], **conteudo)
+            raise FailedRequest(status=resposta["http_status"], **conteudo)
 
         return Processo.from_json(resposta["resposta"], resposta.get("links", {}).get("next", ""))
 
@@ -110,7 +110,7 @@ class Processo(DataEndpoint):
 
         if not first_response["sucesso"]:
             conteudo = first_response.get("resposta", {})
-            return FailedRequest(status=first_response["http_status"], **conteudo)
+            raise FailedRequest(status=first_response["http_status"], **conteudo)
 
         return json_to_class(first_response, constructor=Movimentacao.from_json, add_cursor=True)
 
@@ -270,7 +270,7 @@ class Processo(DataEndpoint):
 
         if not first_response["sucesso"]:
             conteudo = first_response.get("resposta", {})
-            return FailedRequest(status=first_response["http_status"], **conteudo)
+            raise FailedRequest(status=first_response["http_status"], **conteudo)
 
         envolvido_encontrado = EnvolvidoEncontrado.from_json(
             first_response["resposta"].get("envolvido_encontrado"),
@@ -317,7 +317,7 @@ class Processo(DataEndpoint):
 
         if not first_response["sucesso"]:
             conteudo = first_response.get("resposta", {})
-            return FailedRequest(status=first_response["http_status"], **conteudo)
+            raise FailedRequest(status=first_response["http_status"], **conteudo)
 
         advogado_encontrado = EnvolvidoEncontrado.from_json(
             first_response["resposta"].get("advogado_encontrado"),
@@ -339,7 +339,7 @@ class Processo(DataEndpoint):
 
             if not resposta["sucesso"]:
                 conteudo = resposta.get("resposta", {})
-                return FailedRequest(status=resposta["http_status"], **conteudo)
+                raise FailedRequest(status=resposta["http_status"], **conteudo)
 
             return json_to_class(resposta, self.from_json, add_cursor=True)
 

--- a/escavador/v2/resources/tribunal.py
+++ b/escavador/v2/resources/tribunal.py
@@ -65,7 +65,7 @@ class Tribunal(DataEndpoint):
         response = Tribunal.methods.get("tribunais", params=params)
         if not response["sucesso"]:
             conteudo = response.get("resposta", {})
-            return FailedRequest(status=response["http_status"], **conteudo)
+            raise FailedRequest(status=response["http_status"], **conteudo)
 
         return json_to_class(response, Tribunal.from_json, add_cursor=False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "escavador"
-version = "0.4.2"
-description = "A library to  interact with Escavador API"
+version = "0.5.0"
+description = "A library to interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",
     "Gabriel <gabriel@escavador.com>"
@@ -41,8 +41,6 @@ exclude = '''
   | dist
 )/
 '''
-
-[tool.poetry.dev-dependencies]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,25 @@ dataclasses = "*"
 importlib = "*"
 importlib_metadata = "*"
 
+[tool.black]
+line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''
+
 [tool.poetry.dev-dependencies]
 
 [build-system]


### PR DESCRIPTION
Esse MR trata o problema que ocorria ao retornar FailedRequest em um método em que se espera uma tupla de resultados.

Por exemplo, ao fazer:

```
envolvido, processos = v2.Processo.por_envolvido("Nome da Pessoa", "12345678900") # não é possível buscar por CPF e nome ao mesmo tempo
```

Eleva-se um TypeError: FailedRequest is not iterable.

Por considerar que essa mensagem de erro pode causar confusão, resolvemos sempre elevar o FailedRequest na ocasião de erros na solicitação à API V2.

Além disso, esse MR implementa o método `__eq__` nas classes v2.EnvolvidoEncontrado e v2.Envolvido, permitindo que se compare um EnvolvidoEncontrado com um Envolvido, e vice-versa.

Por último, o MR também faz ajustes nos atributos que são incluídos da representação de um objeto de cada dataclass, omitindo atributos como last_valid_cursor ou _classe_buscada. 