### PR TITLE
Coloca publicação e testes para executar no ubuntu-20.04 e python 3.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Python 3.6 is not supported by ubuntu-latest
     needs: [ run-tests ]
 
     steps:

--- a/.github/workflows/run_tests_all_versions.yml
+++ b/.github/workflows/run_tests_all_versions.yml
@@ -8,6 +8,12 @@ on:
 
 jobs:
 
+  call-tests-3-6:
+    uses: ./.github/workflows/tests.yml
+    with:
+      version: "3.6"
+    secrets: inherit
+
   call-tests-3-7:
     uses: ./.github/workflows/tests.yml
     with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,11 @@ on:
         description: "Python version to use"
         type: string
         required: false
-        default: "3.7"
+        default: "3.6"
 
 jobs:
   build-and-run-tests:
-    runs-on: ubuntu-latest # Python 3.7 is the oldest version currently supported by ubuntu-latest
+    runs-on: ubuntu-20.04 # Python 3.6 is not supported by ubuntu-latest
 
     steps:
       - name: Checkout sources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ cchardet = "^2.1.7"
 python-dotenv = "^0.19.2"
 ratelimit = "*"
 dataclasses = "*"
-importlib = "*"
 importlib_metadata = "*"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.5.0"
+version = "0.5.1"
 description = "A library to interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",


### PR DESCRIPTION
Adiciona etapa de testes no Python 3.6 e corrige a instância do container onde é executado o job de publicação do pacote para que seja compatível com o Python 3.6.