### PR TITLE
Remove dependência deprecada e desnecessária

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.5.0"
+version = "0.5.1"
 description = "A library to interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",
@@ -16,7 +16,6 @@ keywords = ["escavador", "api", "python"]
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.27.1"
-cchardet = "^2.1.7"
 python-dotenv = "^0.19.2"
 ratelimit = "*"
 dataclasses = "*"


### PR DESCRIPTION
Alguns usuários vêm tendo problemas com a instalação do cchardet, que não é mais utilizada na biblioteca. Esse MR retira esse requisito do pyproject.toml.