### PR TITLE
Novas rotas, filtros e parâmetros

### DIFF
--- a/escavador/exceptions.py
+++ b/escavador/exceptions.py
@@ -40,9 +40,10 @@ class FailedRequest(Exception):
             raise self
 
     def __str__(self):
-        return f"Erro {self.code} ({self.status}): {self.message}\n" + "\n".join(
-            f"{k}: {v}" for k, v in self.errors.items()
+        error_details = (
+            ("\n" + "\n".join(f"{k}: {v}" for k, v in self.errors.items())) if self.errors else ""
         )
+        return f"Erro {self.code} ({self.status}): {self.message}{error_details}"
 
     def __repr__(self):
         return f"{self.__str__()}\n{self.errors}"

--- a/escavador/exceptions.py
+++ b/escavador/exceptions.py
@@ -15,26 +15,34 @@ class FailedRequest(Exception):
     :attr mensagem: mensagem de erro
     :attr erros: detalhamento dos erros encontrados
     """
+
     status: int
     code: str
     message: str
     errors: Dict
 
-    def __init__(self, status: int,
-                 code: str = "",
-                 message: str = "",
-                 errors: Dict = {},
-                 error: str = "",
-                 **kwargs):
+    def __init__(
+        self,
+        status: int,
+        code: str = "",
+        message: str = "",
+        errors: Dict = {},
+        error: str = "",
+        **kwargs,
+    ):
         self.status = status
         self.code = code
-        self.message = message or error  # unauthenticated e "créditos insuficientes" tem estrutura diferente
+        self.message = (
+            message or error
+        )  # unauthenticated e "créditos insuficientes" têm estrutura diferente
         self.errors = errors
         if self.status == 401:
             raise self
 
     def __str__(self):
-        return f"Erro {self.code} ({self.status}): {self.message}"
+        return f"Erro {self.code} ({self.status}): {self.message}\n" + "\n".join(
+            f"{k}: {v}" for k, v in self.errors.items()
+        )
 
     def __repr__(self):
         return f"{self.__str__()}\n{self.errors}"

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -189,6 +189,9 @@ class Envolvido(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
     ) -> Union[Tuple[Optional[EnvolvidoEncontrado], List["Processo"]], FailedRequest]:
@@ -199,10 +202,16 @@ class Envolvido(DataEndpoint):
         :param ordena_por: critério de ordenação dos resultados
         :param ordem: ordem de ordenação dos resultados
         :param tribunais: lista de tribunais para filtrar os resultados
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
-        :return tupla com os dados do envolvido encontrado e uma lista de processos,
-        ou FailedRequest caso ocorra algum erro
+        :return tupla com os dados do envolvido encontrado e uma lista de processos
         """
         from escavador.v2 import Processo
 
@@ -212,6 +221,9 @@ class Envolvido(DataEndpoint):
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            status=status,
+            data_minima=data_minima,
+            data_maxima=data_maxima,
             limit=limit,
             **kwargs,
         )

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -189,6 +189,7 @@ class Envolvido(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Union[Tuple[Optional[EnvolvidoEncontrado], List["Processo"]], FailedRequest]:
         """Busca os processos envolvendo uma pessoa ou instituição a partir de seu nome e/ou CPF/CNPJ.
@@ -198,6 +199,8 @@ class Envolvido(DataEndpoint):
         :param ordena_por: critério de ordenação dos resultados
         :param ordem: ordem de ordenação dos resultados
         :param tribunais: lista de tribunais para filtrar os resultados
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
         """
@@ -209,6 +212,7 @@ class Envolvido(DataEndpoint):
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            limit=limit,
             **kwargs,
         )
 

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -68,7 +68,7 @@ class EnvolvidoEncontrado:
             return None
 
         tipo_pessoa = json_dict.get(
-            "tipo_pessoa", "FISICA"
+            "tipo_pessoa", json_dict.get("tipo", "FISICA")
         )  # Se não houver tipo_pessoa, assume-se que é advogado, isto é, pessoa física.
         return cls(
             nome=json_dict["nome"],
@@ -238,6 +238,21 @@ class Envolvido(DataEndpoint):
         from escavador.v2 import Processo
 
         return Processo.resumo_envolvido(cpf_cnpj=cpf_cnpj, nome=nome, **kwargs)
+
+    @staticmethod
+    def resumo_oab(
+        numero: int, estado: str, tipo: Optional[str] = None, **kwargs
+    ) -> EnvolvidoEncontrado:
+        """Busca um envolvido a partir de seu número de OAB.
+
+        :param numero: número da OAB do envolvido
+        :param estado: estado da OAB do envolvido
+        :param tipo: tipo da OAB do envolvido
+        :return: envolvido encontrado
+        """
+        from escavador.v2 import Processo
+
+        return Processo.resumo_oab(numero=numero, estado=estado, tipo=tipo, **kwargs)
 
     def __eq__(self, other):
         if isinstance(other, EnvolvidoEncontrado):

--- a/escavador/v2/resources/envolvido.py
+++ b/escavador/v2/resources/envolvido.py
@@ -74,9 +74,7 @@ class EnvolvidoEncontrado:
             nome=json_dict["nome"],
             tipo_pessoa=tipo_pessoa,
             quantidade_processos=json_dict["quantidade_processos"],
-            cpfs_com_esse_nome=json_dict.get(
-                "cpfs_com_esse_nome", 1 if tipo_pessoa == "FISICA" else 0
-            ),
+            cpfs_com_esse_nome=json_dict.get("cpfs_com_esse_nome", None),
             last_valid_cursor=last_cursor,
             _classe_buscada=classe_buscada,
         )
@@ -181,9 +179,8 @@ class Envolvido(DataEndpoint):
     def documento(self) -> Optional[str]:
         return self.cpf or self.cnpj
 
-    @classmethod
+    @staticmethod
     def processos(
-        cls,
         cpf_cnpj: Optional[str] = None,
         nome: Optional[str] = None,
         ordena_por: Optional[CriterioOrdenacao] = None,
@@ -227,6 +224,20 @@ class Envolvido(DataEndpoint):
             limit=limit,
             **kwargs,
         )
+
+    @staticmethod
+    def resumo(
+        cpf_cnpj: Optional[str] = None, nome: Optional[str] = None, **kwargs
+    ) -> EnvolvidoEncontrado:
+        """Busca um envolvido a partir de seu nome e/ou CPF/CNPJ.
+
+        :param cpf_cnpj: CPF ou CNPJ do envolvido
+        :param nome: nome do envolvido
+        :return: envolvido encontrado
+        """
+        from escavador.v2 import Processo
+
+        return Processo.resumo_envolvido(cpf_cnpj=cpf_cnpj, nome=nome, **kwargs)
 
     def __eq__(self, other):
         if isinstance(other, EnvolvidoEncontrado):

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -214,6 +214,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -223,6 +224,8 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -231,13 +234,15 @@ class Processo(DataEndpoint):
         >>> Processo.por_nome("Escavador Engenharia e Construcoes Ltda",
         ...                   ordena_por=CriterioOrdenacao.INICIO,
         ...                   ordem=Ordem.DESC,
-        ...                   tribunais=[SiglaTribunal.CNJ, SiglaTribunal.TRT10]) # doctest: +SKIP
+        ...                   tribunais=[SiglaTribunal.CNJ, SiglaTribunal.TRT10],
+        ...                   limit=100) # doctest: +SKIP
         """
         return Processo.por_envolvido(
             nome=nome,
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            limit=limit,
             **kwargs,
         )
 
@@ -248,6 +253,7 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -262,6 +268,8 @@ class Processo(DataEndpoint):
         :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
         especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
         diferente. Só é permitido se cpf_cnpj for informado.
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -271,7 +279,8 @@ class Processo(DataEndpoint):
         ...                  ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                  ordem=Ordem.ASC,
         ...                  tribunais=[SiglaTribunal.STF],
-        ...                  incluir_homonimos=True) # doctest: +SKIP
+        ...                  incluir_homonimos=True,
+        ...                  limit=100) # doctest: +SKIP
         """
         return Processo.por_envolvido(
             cpf_cnpj=cpf,
@@ -279,6 +288,7 @@ class Processo(DataEndpoint):
             ordem=ordem,
             tribunais=tribunais,
             incluir_homonimos=incluir_homonimos,
+            limit=limit,
             **kwargs,
         )
 
@@ -288,6 +298,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -299,6 +310,8 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -307,13 +320,15 @@ class Processo(DataEndpoint):
         >>> Processo.por_cnpj("07.838.351/0021.60",
         ...                        ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                        ordem=Ordem.ASC,
-        ...                        tribunais=[SiglaTribunal.TJBA, SiglaTribunal.TRF1]) # doctest: +SKIP
+        ...                        tribunais=[SiglaTribunal.TJBA, SiglaTribunal.TRF1],
+        ...                        limit=100) # doctest: +SKIP
         """
         return Processo.por_envolvido(
             cpf_cnpj=cnpj,
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            limit=limit,
             **kwargs,
         )
 
@@ -325,6 +340,7 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -340,6 +356,8 @@ class Processo(DataEndpoint):
         :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
         especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
         diferente. Só é permitido se cpf_cnpj for informado.
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return: tupla com os dados do envolvido encontrado e uma lista de processos,
         ou FailedRequest caso ocorra algum erro
 
@@ -348,7 +366,8 @@ class Processo(DataEndpoint):
         >>> Processo.por_envolvido(nome='Escavador Engenharia e Construcoes Ltda',
         ...                             ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                             ordem=Ordem.ASC,
-        ...                             tribunais=[SiglaTribunal.TJBA]) # doctest: +SKIP
+        ...                             tribunais=[SiglaTribunal.TJBA],
+        ...                             limit=100) # doctest: +SKIP
         """
 
         params = {
@@ -357,6 +376,7 @@ class Processo(DataEndpoint):
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
             "tribunais[]": tribunais,
+            "limit": limit,
             "incluir_homonimos": int(incluir_homonimos) if incluir_homonimos is not None else None,
         }
 
@@ -382,6 +402,7 @@ class Processo(DataEndpoint):
         estado: str,
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
+        limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -391,6 +412,8 @@ class Processo(DataEndpoint):
         :param estado: o estado de origem da OAB
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
+        :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
+        valores permitidos, resultará em uma exceção.
         :return: uma lista de processos, ou FailedRequest caso ocorra algum erro
 
         >>> Processo.por_oab(1234, "AC") # doctest: +SKIP
@@ -398,13 +421,15 @@ class Processo(DataEndpoint):
         >>> Processo.por_oab(numero="12345",
         ...                  estado="SP",
         ...                  ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
-        ...                  ordem=Ordem.DESC) # doctest: +SKIP
+        ...                  ordem=Ordem.DESC,
+        ...                  limit=100) # doctest: +SKIP
         """
         params = {
             "oab_numero": f"{numero}",
             "oab_estado": estado,
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
+            "limit": limit,
         }
 
         first_response = Processo.methods.get("advogado/processos", params=params, **kwargs)

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -403,6 +403,7 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         limit: Optional[int] = None,
+        oab_tipo: Optional[str] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
         """
@@ -414,6 +415,8 @@ class Processo(DataEndpoint):
         :param ordem: determina ordenação ascendente ou descendente
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
+        :param oab_tipo: Tipo da OAB. Pode ser informado caso o mesmo número exista para diferentes tipos.
+        Pode ser 'ADVOGADO', 'SUPLEMENTAR', 'ESTAGIARIO' ou 'CONSULTOR_ESTRANGEIRO'.
         :return: uma lista de processos, ou FailedRequest caso ocorra algum erro
 
         >>> Processo.por_oab(1234, "AC") # doctest: +SKIP
@@ -422,7 +425,8 @@ class Processo(DataEndpoint):
         ...                  estado="SP",
         ...                  ordena_por=CriterioOrdenacao.ULTIMA_MOVIMENTACAO,
         ...                  ordem=Ordem.DESC,
-        ...                  limit=100) # doctest: +SKIP
+        ...                  limit=100,
+        ...                  oab_tipo="ESTAGIARIO") # doctest: +SKIP
         """
         params = {
             "oab_numero": f"{numero}",
@@ -430,6 +434,7 @@ class Processo(DataEndpoint):
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
             "limit": limit,
+            "oab_tipo": oab_tipo,
         }
 
         first_response = Processo.methods.get("advogado/processos", params=params, **kwargs)

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -537,6 +537,34 @@ class Processo(DataEndpoint):
 
         return EnvolvidoEncontrado.from_json(resposta["resposta"])
 
+    @staticmethod
+    def resumo_oab(
+        numero: Union[str, int], estado: str, tipo: Optional[str] = None, **kwargs
+    ) -> EnvolvidoEncontrado:
+        """Retorna um resumo do advogado buscado.
+
+        :param numero: o número da OAB do advogado
+        :param estado: o estado de origem da OAB do advogado
+        :param tipo: o tipo da OAB do advogado. Pode ser 'ADVOGADO', 'SUPLEMENTAR',
+        'ESTAGIARIO' ou 'CONSULTOR_ESTRANGEIRO'.
+
+        :return: um objeto `EnvolvidoEncontrado` contendo a quantidade de processos do advogado encontrado
+        """
+
+        params = {
+            "oab_numero": f"{numero}",
+            "oab_estado": estado,
+            "oab_tipo": tipo,
+        }
+
+        resposta = Processo.methods.get(f"advogado/resumo", params=params, **kwargs)
+
+        if not resposta["sucesso"]:
+            conteudo = resposta.get("resposta", {})
+            raise FailedRequest(status=resposta["http_status"], **conteudo)
+
+        return EnvolvidoEncontrado.from_json(resposta["resposta"])
+
     def continuar_busca(self) -> ListaResultados["Processo"]:
         """Retorna mais resultados para a busca que gerou o processo atual.
 

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -514,6 +514,29 @@ class Processo(DataEndpoint):
             first_response, Processo.from_json, add_cursor=True
         )
 
+    @staticmethod
+    def resumo_envolvido(
+        cpf_cnpj: Optional[str] = None, nome: Optional[str] = None, **kwargs
+    ) -> EnvolvidoEncontrado:
+        """Retorna um resumo do envolvido buscado.
+
+        :param cpf_cnpj: o CPF/CNPJ do envolvido. Obrigatório se não for informado o nome.
+        :param nome: o nome do envolvido. Obrigatório se não for informado o CPF/CNPJ.
+        :return: um objeto `EnvolvidoEncontrado` contendo a quantidade de processos do envolvido encontrado
+        """
+        params = {
+            "cpf_cnpj": cpf_cnpj,
+            "nome": nome,
+        }
+
+        resposta = Processo.methods.get(f"envolvido/resumo", params=params, **kwargs)
+
+        if not resposta["sucesso"]:
+            conteudo = resposta.get("resposta", {})
+            raise FailedRequest(status=resposta["http_status"], **conteudo)
+
+        return EnvolvidoEncontrado.from_json(resposta["resposta"])
+
     def continuar_busca(self) -> ListaResultados["Processo"]:
         """Retorna mais resultados para a busca que gerou o processo atual.
 

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -192,7 +192,7 @@ class Processo(DataEndpoint):
         Busca as movimentações de um processo pelo seu número único do CNJ.
 
         :param numero_cnj: o número único do CNJ do processo
-        :return: uma lista de movimentacoes, ou FailedRequest caso ocorra algum erro
+        :return: uma lista de movimentacoes
 
         >>> Processo.movimentacoes("0000000-00.0000.0.00.0000") # doctest: +SKIP
         """
@@ -214,6 +214,9 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
@@ -224,10 +227,16 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
-        :return: tupla com os dados do envolvido encontrado e uma lista de processos,
-        ou FailedRequest caso ocorra algum erro
+        :return: tupla com os dados do envolvido encontrado e uma lista de processos
 
         >>> Processo.por_nome("Escavador Engenharia e Construcoes Ltda") # doctest: +SKIP
 
@@ -242,6 +251,9 @@ class Processo(DataEndpoint):
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            status=status,
+            data_minima=data_minima,
+            data_maxima=data_maxima,
             limit=limit,
             **kwargs,
         )
@@ -253,6 +265,9 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
@@ -268,10 +283,16 @@ class Processo(DataEndpoint):
         :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
         especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
         diferente. Só é permitido se cpf_cnpj for informado.
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
-        :return: tupla com os dados do envolvido encontrado e uma lista de processos,
-        ou FailedRequest caso ocorra algum erro
+        :return: tupla com os dados do envolvido encontrado e uma lista de processos
 
         >>> Processo.por_cpf("123.456.789-99") # doctest: +SKIP
 
@@ -288,6 +309,9 @@ class Processo(DataEndpoint):
             ordem=ordem,
             tribunais=tribunais,
             incluir_homonimos=incluir_homonimos,
+            status=status,
+            data_minima=data_minima,
+            data_maxima=data_maxima,
             limit=limit,
             **kwargs,
         )
@@ -298,6 +322,9 @@ class Processo(DataEndpoint):
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
@@ -310,10 +337,16 @@ class Processo(DataEndpoint):
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
         :param tribunais: lista de siglas de tribunais para filtrar a busca
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
-        :return: tupla com os dados do envolvido encontrado e uma lista de processos,
-        ou FailedRequest caso ocorra algum erro
+        :return: tupla com os dados do envolvido encontrado e uma lista de processos
 
         >>> Processo.por_cnpj("07838351002160") # doctest: +SKIP
 
@@ -328,6 +361,9 @@ class Processo(DataEndpoint):
             ordena_por=ordena_por,
             ordem=ordem,
             tribunais=tribunais,
+            status=status,
+            data_minima=data_minima,
+            data_maxima=data_maxima,
             limit=limit,
             **kwargs,
         )
@@ -340,6 +376,9 @@ class Processo(DataEndpoint):
         ordem: Optional[Ordem] = None,
         tribunais: Optional[List[SiglaTribunal]] = None,
         incluir_homonimos: Optional[bool] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         **kwargs,
     ) -> Tuple[Optional[EnvolvidoEncontrado], ListaResultados["Processo"]]:
@@ -356,10 +395,16 @@ class Processo(DataEndpoint):
         :param incluir_homonimos: especifica se a busca por CPF deve incluir processos onde o CPF
         especificado não está associado, mas há envolvido com o nome igual e não associado a um CPF
         diferente. Só é permitido se cpf_cnpj for informado.
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
-        :return: tupla com os dados do envolvido encontrado e uma lista de processos,
-        ou FailedRequest caso ocorra algum erro
+        :return: tupla com os dados do envolvido encontrado e uma lista de processos
 
         >>> Processo.por_envolvido(cpf_cnpj="07.838.351/0021.60") # doctest: +SKIP
 
@@ -376,6 +421,9 @@ class Processo(DataEndpoint):
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
             "tribunais[]": tribunais,
+            "status": status,
+            "data_minima": data_minima,
+            "data_maxima": data_maxima,
             "limit": limit,
             "incluir_homonimos": int(incluir_homonimos) if incluir_homonimos is not None else None,
         }
@@ -402,6 +450,9 @@ class Processo(DataEndpoint):
         estado: str,
         ordena_por: Optional[CriterioOrdenacao] = None,
         ordem: Optional[Ordem] = None,
+        status: Optional[str] = None,
+        data_minima: Optional[str] = None,
+        data_maxima: Optional[str] = None,
         limit: Optional[int] = None,
         oab_tipo: Optional[str] = None,
         **kwargs,
@@ -413,11 +464,18 @@ class Processo(DataEndpoint):
         :param estado: o estado de origem da OAB
         :param ordena_por: critério de ordenação
         :param ordem: determina ordenação ascendente ou descendente
+        :param status: filtra processos a partir do status do processo. Pode ser 'ATIVO' ou 'INATIVO'.
+        Obs. A classificação do status é feito por IA e vai considerar a última atualização que possuímos
+        do processo na nossa base.
+        :param data_minima: filtra processos que iniciaram após a data informada.
+        A data deve ser estar no formato AAAA-MM-DD.
+        :param data_maxima: filtra processos que iniciaram antes da data informada.
+        A data deve ser estar no formato AAAA-MM-DD, e caso a data mínima seja informada, deve ser maior que ela.
         :param limit: quantidade de resultados desejados por página. Se não estiver dentro dos
         valores permitidos, resultará em uma exceção.
         :param oab_tipo: Tipo da OAB. Pode ser informado caso o mesmo número exista para diferentes tipos.
         Pode ser 'ADVOGADO', 'SUPLEMENTAR', 'ESTAGIARIO' ou 'CONSULTOR_ESTRANGEIRO'.
-        :return: uma lista de processos, ou FailedRequest caso ocorra algum erro
+        :return: uma tupla contendo um objeto representando o advogado encontrado e a lista de processos
 
         >>> Processo.por_oab(1234, "AC") # doctest: +SKIP
 
@@ -433,6 +491,9 @@ class Processo(DataEndpoint):
             "oab_estado": estado,
             "ordena_por": ordena_por.value if ordena_por else None,
             "ordem": ordem.value if ordem else None,
+            "status": status,
+            "data_minima": data_minima,
+            "data_maxima": data_maxima,
             "limit": limit,
             "oab_tipo": oab_tipo,
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.7.0"
+version = "0.8.0"
 description = "A library to interact with Escavador API"
 authors = [
     "Rafael <rafaelcampos@escavador.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ keywords = ["escavador", "api", "python"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
-requests = "^2.27.1"
-python-dotenv = "^0.19.2"
+requests = ">= 2.27.1"
+python-dotenv = ">= 0.19.2"
 ratelimit = "*"
 dataclasses = "*"
 importlib_metadata = "*"


### PR DESCRIPTION
Implementa as seguintes funcionalidades:

- Especificar o limite de resultados por página nas buscas de processos por envolvido ou por OAB (limit=100)
- Parâmetro opcional oab_tipo na rota Processos de um advogado por OAB e rota de resumo por OAB
- Rota de resumo de Processos do advogado por OAB (tanto na classe Envolvido quanto na classe Processo)
- Resumo por envolvido (tanto na classe Envolvido quanto na classe Processo)
- filtros das rotas de processos do envolvido
  - status (ATIVO/INATIVO)
  - data_minima
  - data_maxima
 
 Além disso, atualiza a documentação em docstrings para refletir as mudanças mais recentes.
 
 Closes #21 