### PR TITLE
Remove suporte ao python3.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     secrets: inherit
 
   build-and-publish:
-    runs-on: ubuntu-20.04 # Python 3.6 is not supported by ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [ run-tests ]
 
     steps:
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: "3.7"
 
       - name: Install poetry and dependencies
         run: |

--- a/.github/workflows/run_tests_all_versions.yml
+++ b/.github/workflows/run_tests_all_versions.yml
@@ -8,12 +8,6 @@ on:
 
 jobs:
 
-  call-tests-3-6:
-    uses: ./.github/workflows/tests.yml
-    with:
-      version: "3.6"
-    secrets: inherit
-
   call-tests-3-7:
     uses: ./.github/workflows/tests.yml
     with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,11 @@ on:
         description: "Python version to use"
         type: string
         required: false
-        default: "3.6"
+        default: "3.7"
 
 jobs:
   build-and-run-tests:
-    runs-on: ubuntu-20.04 # Python 3.6 is not supported by ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ python -m pip install escavador
 
 ##  Requisitos
 
-- Python 3.6+
+- Python 3.7+
 
 ## Como Configurar
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.8.0"
+version = "0.9.0"
 description = "A library to interact with Escavador API"
 authors = ["Gabriel <gabriel@escavador.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ python = "^3.7"
 requests = ">= 2.27.1"
 python-dotenv = ">= 0.19.2"
 ratelimit = "*"
-dataclasses = "*"
 importlib_metadata = "*"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,7 @@
 name = "escavador"
 version = "0.8.0"
 description = "A library to interact with Escavador API"
-authors = [
-    "Rafael <rafaelcampos@escavador.com>",
-    "Gabriel <gabriel@escavador.com>",
-    "Luiz <luizcdc@escavador.com>"
-]
+authors = ["Gabriel <gabriel@escavador.com>"]
 readme = "README.md"
 homepage = "https://www.escavador.com"
 repository = "https://github.com/Escavador/escavador-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ license = "MIT"
 keywords = ["escavador", "api", "python"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 requests = ">= 2.27.1"
 python-dotenv = ">= 0.19.2"
 ratelimit = "*"


### PR DESCRIPTION
## Remove suporte ao python3.6

A biblioteca `dataclasses` que era utilizada para retrocompatibilidade com o python3.6 está criando conflitos com versões mais recentes do python (ver #22).

Esse MR remove `dataclasses` das dependências e altera a versão mínima do python necessária para utilização do SDK (para 3.7 ou superior).

Também foram feitas alterações nas documentações e workflows.