### PR TITLE
Adiciona parâmetros em rota de atualização de processos

### DIFF
--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -582,13 +582,23 @@ class Processo(DataEndpoint):
         return ListaResultados()
 
     @classmethod
-    def solicitar_atualizacao(cls, numero_cnj: str) -> SolicitacaoAtualizacao:
+    def solicitar_atualizacao(
+        cls, numero_cnj: str, *, enviar_callback: int = 0, documentos_publicos: int = 0
+    ) -> SolicitacaoAtualizacao:
         """Solicita a atualização de um processo.
 
         :param numero_cnj: o processo a ser atualizado
+        :param enviar_callback: Se enviar_callback=1 será enviado um callback quando o processo for atualizado.
+        Obrigatório ter uma url de callback.
+        :param documentos_publicos: Se documentos_publicos=1 será baixado os documentos públicos do processo.
         :return: informações sobre a solicitação de atualização
         """
-        resposta = Processo.methods.post(f"processos/numero_cnj/{numero_cnj}/solicitar-atualizacao")
+        data = {"documentos_publicos": documentos_publicos}
+        if enviar_callback:
+            data["enviar_callback"] = 1
+        resposta = Processo.methods.post(
+            f"processos/numero_cnj/{numero_cnj}/solicitar-atualizacao",
+        )
 
         if not resposta["sucesso"]:
             conteudo = resposta.get("resposta", {})

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -593,9 +593,10 @@ class Processo(DataEndpoint):
         :param documentos_publicos: Se documentos_publicos=1 será baixado os documentos públicos do processo.
         :return: informações sobre a solicitação de atualização
         """
-        data = {"documentos_publicos": documentos_publicos}
-        if enviar_callback:
-            data["enviar_callback"] = enviar_callback
+        data = {
+            "documentos_publicos": documentos_publicos,
+            "enviar_callback": enviar_callback,
+        }
 
         resposta = Processo.methods.post(
             f"processos/numero_cnj/{numero_cnj}/solicitar-atualizacao",

--- a/escavador/v2/resources/processo.py
+++ b/escavador/v2/resources/processo.py
@@ -595,9 +595,11 @@ class Processo(DataEndpoint):
         """
         data = {"documentos_publicos": documentos_publicos}
         if enviar_callback:
-            data["enviar_callback"] = 1
+            data["enviar_callback"] = enviar_callback
+
         resposta = Processo.methods.post(
             f"processos/numero_cnj/{numero_cnj}/solicitar-atualizacao",
+            data=data,
         )
 
         if not resposta["sucesso"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "escavador"
-version = "0.9.0"
+version = "0.9.1"
 description = "A library to interact with Escavador API"
 authors = ["Gabriel <gabriel@escavador.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Descrição

A rota `api/v2/processos/numero_cnj/{numero}/solicitar-atualizacao` pode receber dois parâmetros (`enviar_callback` e `documentos_publicos`), mas o método `solicitar_atualizacao` da classe `Processo` não recebia nenhum parâmetro.

Esse PR adiciona os dois parâmetros ao método `solicitar_atualizacao`.