### PR TITLE
Add atributo appends em FailedRequest

### DIFF
--- a/escavador/exceptions.py
+++ b/escavador/exceptions.py
@@ -20,14 +20,16 @@ class FailedRequest(Exception):
     code: str
     message: str
     errors: Dict
+    appends: Dict
 
     def __init__(
         self,
         status: int,
         code: str = "",
         message: str = "",
-        errors: Dict = {},
+        errors: Dict = None,
         error: str = "",
+        appends: Dict = None,
         **kwargs,
     ):
         self.status = status
@@ -35,7 +37,8 @@ class FailedRequest(Exception):
         self.message = (
             message or error
         )  # unauthenticated e "créditos insuficientes" têm estrutura diferente
-        self.errors = errors
+        self.errors = errors or {}
+        self.appends = appends or {}
         if self.status == 401:
             raise self
 


### PR DESCRIPTION
### Descrição

O campo appends estava sendo suprimido na instanciação de `FailedRequest`.

Esse MR adiciona o atributo na classe.

Além disso, altera o valor default de `errors` para `None`. Valores mutáveis, como dicts, não devem ser utilizados como default, pois podem gerar comportamentos inesperados.