### PR TITLE
Update python-version em publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
 
       - name: Install poetry and dependencies
         run: |


### PR DESCRIPTION
### Descrição

Corrige a versão do python utilizada em `.github/workflows/publish.yml` para o python3.12. A versão 3.7 do python não é mais incluída na versão mais recente do ubuntu.